### PR TITLE
Make download directory a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ gitlab_ci_multi_runner_addl_groups:
 gitlab_ci_multi_runner_concurrent_runners_per_host: 1
 gitlab_ci_multi_runner_check_gitlab_new_builds_interval: 0
 gitlab_ci_multi_runner_activate: True
+gitlab_ci_multi_runner_dl_dir: /tmp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,13 +15,13 @@
   become_user: root
   get_url:
     url: '{{ gitlab_ci_multi_runner_url }}'
-    dest: /tmp/gitlab-runner.sh
+    dest: '{{ gitlab_ci_multi_runner_dl_dir }}/gitlab-runner.sh'
     mode: 0755
 
 - name: running bootstrap script
   become: yes
   become_user: root
-  command: /tmp/gitlab-runner.sh
+  command: '{{ gitlab_ci_multi_runner_dl_dir }}/gitlab-runner.sh'
   args:
     creates: /usr/bin/gitlab-runner
 


### PR DESCRIPTION
defaults/main.yml:
    * Add variable `gitlab_ci_multi_runner_dl_dir`, default to /tmp

tasks/main.yml:
    * Use gitlab_ci_multi_runner_dl_dir variable

At times, the machine that we run the Ansible playbook against does
not have /tmp mounted exec. So we need to have the install script
stored at other place. Alternatively, we can use something like
"bash gitlab-runner.sh".

It is not the VM that we want to Ansible but the machine that we have
to.

Signed-off-by: Tuan T. Pham <tuan@vt.edu>